### PR TITLE
reset continuous scales to modifier pattern

### DIFF
--- a/Sources/SwiftVizScale/ContinuousScale.swift
+++ b/Sources/SwiftVizScale/ContinuousScale.swift
@@ -44,11 +44,6 @@ public protocol ContinuousScale {
     /// are constrained to the input domain.
     var transformType: DomainDataTransform { get }
 
-    /// A Boolean value that indicates the scale was configured without an explicit domain.
-    ///
-    /// Use `something` to create a new scale with an explicit domain while keeping the same ``transformType``.
-    var defaultDomain: Bool { get }
-
     /// The lower bound of the input domain.
     var domainLower: InputType { get }
     /// The upper bound of the input domain.
@@ -61,12 +56,27 @@ public protocol ContinuousScale {
     /// - Returns: `true` if the value is between the lower and upper domain values.
     func domainContains(_ value: InputType) -> Bool
 
+    // modifier functions
+
     /// Returns a new scale with the domain set to the values you provide.
     /// - Parameters:
     ///   - lower: The lower bound for the scale's domain.
     ///   - higher: The upper bound for the scale's domain.
-    /// - Returns: A replica of the scale, preserving ``transformType`` while applying new domain values.
-    func withDomain(lower: InputType, higher: InputType) -> Self
+    /// - Returns: A replica of the scale, with new domain values.
+    func domain(lower: InputType, higher: InputType) -> Self
+
+    /// Returns a new scale with the range set to the values you provide.
+    /// - Parameters:
+    ///   - lower: The lower bound for the scale's range.
+    ///   - higher: The upper bound for the scale's range.
+    /// - Returns: A replica of the scale, with new range values.
+    func range(lower: OutputType, higher: OutputType) -> Self
+
+    /// Returns a new scale with the transform set to the value you provide.
+    /// - Parameters:
+    ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
+    /// - Returns: A replica of the scale, updating the ``transformType``.
+    func transform(_ transform: DomainDataTransform) -> Self
 
     /// Converts a value comparing it to the input domain, transforming the value, and mapping it between the range values you provide.
     ///

--- a/Sources/SwiftVizScale/LinearScale.swift
+++ b/Sources/SwiftVizScale/LinearScale.swift
@@ -10,16 +10,16 @@ public struct LinearScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
     /// The distance or length between the upper and lower bounds of the input domain.
     public let domainExtent: InputType
 
+    /// The lower bound of the input domain.
+    public let rangeLower: OutputType?
+    /// The upper bound of the input domain.
+    public let rangeHigher: OutputType?
+
     /// A transformation value that indicates whether the output vales are constrained to the min and max of the output range.
     ///
     /// If `true`, values processed by the scale are constrained to the output range, and values processed backwards through the scale
     /// are constrained to the input domain.
     public var transformType: DomainDataTransform
-
-    /// A Boolean value that indicates the scale was configured without an explicit domain.
-    ///
-    /// Use ``withDomain(lower:higher:)`` to create a new scale with an explicit domain while keeping the same ``transformType``.
-    public var defaultDomain: Bool
 
     /// The number of ticks desired when creating the scale.
     ///
@@ -32,26 +32,23 @@ public struct LinearScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
     ///   - higher: The upper bound for the scale's domain.
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(from lower: InputType, to higher: InputType, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        precondition(lower < higher)
+    public init(from lower: InputType = 0, to higher: InputType = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
+        precondition(lower < higher, "attempting to set an inverted or empty domain: \(lower) to \(higher)")
         transformType = transform
         domainLower = lower
         domainHigher = higher
         domainExtent = higher - lower
         self.desiredTicks = desiredTicks
-        defaultDomain = false
+        if let rangeLower = rangeLower, let rangeHigher = rangeHigher {
+            precondition(lower < higher, "attempting to set an inverted or empty range: \(rangeLower) to \(rangeHigher)")
+        }
+        self.rangeLower = rangeLower
+        self.rangeHigher = rangeHigher
     }
 
-    /// Creates a new linear scale with a default domain.
-    ///
-    /// The default domain for the scale is `0.0...1.0`.
-    /// Use this method to create a placeholder scale that you can refine to a fully configured scale with an updated domain using ``withDomain(lower:higher:)``.
-    /// - Parameters:
-    ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
-    ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(exponent _: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        self.init(from: 0, to: 1, transform: transform, desiredTicks: desiredTicks)
-        defaultDomain = true
+    // testing function
+    internal func fullyConfigured() -> Bool {
+        rangeLower != nil && rangeHigher != nil
     }
 
     /// Creates a new linear scale for the upper and lower bounds of the domain range you provide.
@@ -59,8 +56,8 @@ public struct LinearScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
     ///   - range: A range that represents the scale's domain.
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(_ range: ClosedRange<InputType>, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        self.init(from: range.lowerBound, to: range.upperBound, transform: transform, desiredTicks: desiredTicks)
+    public init(_ range: ClosedRange<InputType>, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
+        self.init(from: range.lowerBound, to: range.upperBound, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
     }
 
     /// Creates a new power scale for the domain of `0` to the value you provide.
@@ -71,21 +68,71 @@ public struct LinearScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
     ///   - single: The upper, or lower, bound for the domain.
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(_ single: InputType, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
+    public init(_ single: InputType, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
         if single > 0 {
-            self.init(from: 0, to: single, transform: transform, desiredTicks: desiredTicks)
+            self.init(from: 0, to: single, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
         } else {
-            self.init(from: single, to: 0, transform: transform, desiredTicks: desiredTicks)
+            self.init(from: single, to: 0, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
         }
     }
+
+    // MARK: - modifier functions
 
     /// Returns a new scale with the domain set to the values you provide.
     /// - Parameters:
     ///   - lower: The lower bound for the scale's domain.
     ///   - higher: The upper bound for the scale's domain.
-    /// - Returns: A replica of the scale, preserving ``transformType`` while applying new domain values.
-    public func withDomain(lower: InputType, higher: InputType) -> LinearScale<InputType, OutputType> {
-        type(of: self).init(from: lower, to: higher, transform: transformType, desiredTicks: desiredTicks)
+    /// - Returns: A copy of the scale with the domain values you provide.
+    public func domain(lower: InputType, higher: InputType) -> Self {
+        type(of: self).init(from: lower, to: higher, transform: transformType, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    /// Returns a new scale with the domain set to the values you provide.
+    /// - Parameters:
+    ///   - range: The range to apply as the scale's domain
+    /// - Returns: A copy of the scale with the domain values you provide.
+    public func domain(_ range: ClosedRange<InputType>) -> Self {
+        type(of: self).init(from: range.lowerBound, to: range.upperBound, transform: transformType, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    /// Returns a new scale with the range set to the values you provide.
+    /// - Parameters:
+    ///   - lower: The lower bound for the scale's range.
+    ///   - higher: The upper bound for the scale's range.
+    /// - Returns: A copy of the scale with the range values you provide.
+    public func range(lower: OutputType, higher: OutputType) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transformType, desiredTicks: desiredTicks, rangeLower: lower, rangeHigher: higher)
+    }
+
+    /// Returns a new scale with the range set to the values you provide.
+    /// - Parameters:
+    ///   - range: The range to apply as the scale's range.
+    /// - Returns: A copy of the scale with the range values you provide.
+    public func range(_ range: ClosedRange<OutputType>) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transformType, desiredTicks: desiredTicks, rangeLower: range.lowerBound, rangeHigher: range.upperBound)
+    }
+
+    /// Returns a new scale with the transform set to the value you provide.
+    /// - Parameters:
+    ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
+    /// - Returns: A copy of the scale with the transform setting you provide.
+    public func transform(_ transform: DomainDataTransform) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    // MARK: - scale functions
+
+    /// Transforms the input value using a linear function to the resulting value into the range you provide.
+    ///
+    /// - Parameter domainValue: A value in the domain of the scale.
+    /// - Returns: A value mapped to the range you provide.
+    public func scale(_ domainValue: InputType) -> OutputType? {
+        guard let domainValue = transformAgainstDomain(domainValue), let rangeLower = rangeLower, let rangeHigher = rangeHigher else {
+            return nil
+        }
+        let normalizedInput = normalize(domainValue.toDouble(), lower: domainLower.toDouble(), higher: domainHigher.toDouble())
+        let result: Double = interpolate(normalizedInput, lower: rangeLower.toDouble(), higher: rangeHigher.toDouble())
+        return OutputType.fromDouble(result)
     }
 
     /// Transforms the input value using a linear function to the resulting value into the range you provide.
@@ -95,12 +142,25 @@ public struct LinearScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
     /// - Parameter higher: The upper bound of the range to map to.
     /// - Returns: A value mapped to the range you provide.
     public func scale(_ domainValue: InputType, from lower: OutputType, to higher: OutputType) -> OutputType? {
-        if let domainValue = transformAgainstDomain(domainValue) {
-            let normalizedInput = normalize(domainValue.toDouble(), lower: domainLower.toDouble(), higher: domainHigher.toDouble())
-            let result: Double = interpolate(normalizedInput, lower: lower.toDouble(), higher: higher.toDouble())
-            return OutputType.fromDouble(result)
+        let reconfigScale = range(lower: lower, higher: higher)
+        return reconfigScale.scale(domainValue)
+    }
+
+    /// Transforms a value within the range into the associated domain value.
+    /// - Parameters:
+    ///   - rangeValue: A value in the range of the scale.
+    ///   - lower: The lower bound to the range to map from.
+    ///   - higher: The upper bound to the range to map from.
+    /// - Returns: A value linearly mapped from the range back into the domain.
+    public func invert(_ rangeValue: OutputType) -> InputType? {
+        guard let rangeLower = rangeLower, let rangeHigher = rangeHigher else {
+            return nil
         }
-        return nil
+        // inverts the scale, taking a value in the output range and returning the relevant value from the input domain
+        let normalizedRangeValue = normalize(rangeValue.toDouble(), lower: rangeLower.toDouble(), higher: rangeHigher.toDouble())
+        let mappedToDomain = interpolate(normalizedRangeValue, lower: domainLower.toDouble(), higher: domainHigher.toDouble())
+        let castToInputType = InputType.fromDouble(mappedToDomain)
+        return transformAgainstDomain(castToInputType)
     }
 
     /// Transforms a value within the range into the associated domain value.
@@ -110,11 +170,8 @@ public struct LinearScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
     ///   - higher: The upper bound to the range to map from.
     /// - Returns: A value linearly mapped from the range back into the domain.
     public func invert(_ rangeValue: OutputType, from lower: OutputType, to higher: OutputType) -> InputType? {
-        // inverts the scale, taking a value in the output range and returning the relevant value from the input domain
-        let normalizedRangeValue = normalize(rangeValue.toDouble(), lower: lower.toDouble(), higher: higher.toDouble())
-        let mappedToDomain = interpolate(normalizedRangeValue, lower: domainLower.toDouble(), higher: domainHigher.toDouble())
-        let castToInputType = InputType.fromDouble(mappedToDomain)
-        return transformAgainstDomain(castToInputType)
+        let reconfigScale = range(lower: lower, higher: higher)
+        return reconfigScale.invert(rangeValue)
     }
 }
 

--- a/Sources/SwiftVizScale/LogScale.swift
+++ b/Sources/SwiftVizScale/LogScale.swift
@@ -15,16 +15,16 @@ public struct LogScale<InputType: ConvertibleWithDouble & NiceValue, OutputType:
     /// The distance or length between the upper and lower bounds of the input domain.
     public let domainExtent: InputType
 
+    /// The lower bound of the input domain.
+    public let rangeLower: OutputType?
+    /// The upper bound of the input domain.
+    public let rangeHigher: OutputType?
+
     /// A transformation value that indicates whether the output vales are constrained to the min and max of the output range.
     ///
     /// If `true`, values processed by the scale are constrained to the output range, and values processed backwards through the scale
     /// are constrained to the input domain.
     public var transformType: DomainDataTransform
-
-    /// A Boolean value that indicates the scale was configured without an explicit domain.
-    ///
-    /// Use ``withDomain(lower:higher:)`` to create a new scale with an explicit domain while keeping the same ``transformType``.
-    public var defaultDomain: Bool
 
     /// The number of ticks desired when creating the scale.
     ///
@@ -37,27 +37,19 @@ public struct LogScale<InputType: ConvertibleWithDouble & NiceValue, OutputType:
     ///   - higher: The upper bound for the scale's domain.
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(from lower: InputType, to higher: InputType, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        precondition(lower < higher)
-        precondition(lower.toDouble() > 0.0)
+    public init(from lower: InputType = 1, to higher: InputType = 10, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
+        precondition(lower < higher, "attempting to set an inverted or empty domain: \(lower) to \(higher)")
+        precondition(lower.toDouble() > 0.0, "attempting to set a log scale to start at 0.0")
         transformType = transform
         domainLower = lower
         domainHigher = higher
         domainExtent = higher - lower
         self.desiredTicks = desiredTicks
-        defaultDomain = false
-    }
-
-    /// Creates a new logarithmic scale with a default domain.
-    ///
-    /// The default domain for the scale is `1...10`.
-    /// Use this method to create a placeholder scale that you can refine to a fully configured scale with an updated domain using ``withDomain(lower:higher:)``.
-    /// - Parameters:
-    ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
-    ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(exponent _: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        self.init(from: 1, to: 10, transform: transform, desiredTicks: desiredTicks)
-        defaultDomain = true
+        if let rangeLower = rangeLower, let rangeHigher = rangeHigher {
+            precondition(lower < higher, "attempting to set an inverted or empty range: \(rangeLower) to \(rangeHigher)")
+        }
+        self.rangeLower = rangeLower
+        self.rangeHigher = rangeHigher
     }
 
     /// Creates a new logarithmic scale for the upper and lower bounds of the domain range you provide.
@@ -65,17 +57,77 @@ public struct LogScale<InputType: ConvertibleWithDouble & NiceValue, OutputType:
     ///   - range: The range of the scale's domain.
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(_ range: ClosedRange<InputType>, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        self.init(from: range.lowerBound, to: range.upperBound, transform: transform, desiredTicks: desiredTicks)
+    public init(_ range: ClosedRange<InputType>, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
+        self.init(from: range.lowerBound, to: range.upperBound, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
     }
+
+    // testing function
+    internal func fullyConfigured() -> Bool {
+        rangeLower != nil && rangeHigher != nil
+    }
+
+    // MARK: - modifier functions
 
     /// Returns a new scale with the domain set to the values you provide.
     /// - Parameters:
     ///   - lower: The lower bound for the scale's domain.
     ///   - higher: The upper bound for the scale's domain.
-    /// - Returns: A replica of the scale, preserving ``transformType`` while applying new domain values.
-    public func withDomain(lower: InputType, higher: InputType) -> LogScale<InputType, OutputType> {
-        type(of: self).init(from: lower, to: higher, transform: transformType, desiredTicks: desiredTicks)
+    /// - Returns: A copy of the scale with the domain values you provide.
+    public func domain(lower: InputType, higher: InputType) -> Self {
+        type(of: self).init(from: lower, to: higher, transform: transformType, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    /// Returns a new scale with the domain set to the values you provide.
+    /// - Parameters:
+    ///   - range: The range to apply as the scale's domain
+    /// - Returns: A copy of the scale with the domain values you provide.
+    public func domain(_ range: ClosedRange<InputType>) -> Self {
+        type(of: self).init(from: range.lowerBound, to: range.upperBound, transform: transformType, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    /// Returns a new scale with the range set to the values you provide.
+    /// - Parameters:
+    ///   - lower: The lower bound for the scale's range.
+    ///   - higher: The upper bound for the scale's range.
+    /// - Returns: A copy of the scale with the range values you provide.
+    public func range(lower: OutputType, higher: OutputType) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transformType, desiredTicks: desiredTicks, rangeLower: lower, rangeHigher: higher)
+    }
+
+    /// Returns a new scale with the range set to the values you provide.
+    /// - Parameters:
+    ///   - range: The range to apply as the scale's range.
+    /// - Returns: A copy of the scale with the range values you provide.
+    public func range(_ range: ClosedRange<OutputType>) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transformType, desiredTicks: desiredTicks, rangeLower: range.lowerBound, rangeHigher: range.upperBound)
+    }
+
+    /// Returns a new scale with the transform set to the value you provide.
+    /// - Parameters:
+    ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
+    /// - Returns: A copy of the scale with the transform setting you provide.
+    public func transform(_ transform: DomainDataTransform) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    // MARK: - scale functions
+
+    /// Transforms the input value using a linear function to the resulting value into the range you provide.
+    ///
+    /// - Parameter domainValue: A value in the domain of the scale.
+    /// - Parameter lower: The lower bound to the range to map to.
+    /// - Parameter higher: The upper bound of the range to map to.
+    /// - Returns: A value mapped to the range you provide.
+    public func scale(_ domainValue: InputType) -> OutputType? {
+        guard let domainValue = transformAgainstDomain(domainValue), let rangeLower = rangeLower, let rangeHigher = rangeHigher else {
+            return nil
+        }
+        let logDomainValue = log10(domainValue.toDouble())
+        let logDomainLower = log10(domainLower.toDouble())
+        let logDomainHigher = log10(domainHigher.toDouble())
+        let normalizedValueOnLogDomain = normalize(logDomainValue, lower: logDomainLower, higher: logDomainHigher)
+        let valueMappedToRange = interpolate(normalizedValueOnLogDomain, lower: rangeLower.toDouble(), higher: rangeHigher.toDouble())
+        return OutputType.fromDouble(valueMappedToRange)
     }
 
     /// Transforms the input value using a linear function to the resulting value into the range you provide.
@@ -85,15 +137,27 @@ public struct LogScale<InputType: ConvertibleWithDouble & NiceValue, OutputType:
     /// - Parameter higher: The upper bound of the range to map to.
     /// - Returns: A value mapped to the range you provide.
     public func scale(_ domainValue: InputType, from lower: OutputType, to higher: OutputType) -> OutputType? {
-        if let domainValue = transformAgainstDomain(domainValue) {
-            let logDomainValue = log10(domainValue.toDouble())
-            let logDomainLower = log10(domainLower.toDouble())
-            let logDomainHigher = log10(domainHigher.toDouble())
-            let normalizedValueOnLogDomain = normalize(logDomainValue, lower: logDomainLower, higher: logDomainHigher)
-            let valueMappedToRange = interpolate(normalizedValueOnLogDomain, lower: lower.toDouble(), higher: higher.toDouble())
-            return OutputType.fromDouble(valueMappedToRange)
+        let reconfiguredScale = range(lower: lower, higher: higher)
+        return reconfiguredScale.scale(domainValue)
+    }
+
+    /// Transforms a value within the range into the associated domain value.
+    /// - Parameters:
+    ///   - rangeValue: A value in the range of the scale.
+    ///   - lower: The lower bound to the range to map from.
+    ///   - higher: The upper bound to the range to map from.
+    /// - Returns: A value linearly mapped from the range back into the domain.
+    public func invert(_ rangeValue: OutputType) -> InputType? {
+        guard let rangeLower = rangeLower, let rangeHigher = rangeHigher else {
+            return nil
         }
-        return nil
+        let normalizedRangeValue = normalize(rangeValue.toDouble(), lower: rangeLower.toDouble(), higher: rangeHigher.toDouble())
+        let logDomainLower = log10(domainLower.toDouble())
+        let logDomainHigher = log10(domainHigher.toDouble())
+        let linearInterpolatedValue = interpolate(Double(normalizedRangeValue), lower: logDomainLower, higher: logDomainHigher)
+        let domainValue = pow(10, linearInterpolatedValue)
+        let downcastDomainValue = InputType.fromDouble(domainValue)
+        return transformAgainstDomain(downcastDomainValue)
     }
 
     /// Transforms a value within the range into the associated domain value.
@@ -103,12 +167,7 @@ public struct LogScale<InputType: ConvertibleWithDouble & NiceValue, OutputType:
     ///   - higher: The upper bound to the range to map from.
     /// - Returns: A value linearly mapped from the range back into the domain.
     public func invert(_ rangeValue: OutputType, from lower: OutputType, to higher: OutputType) -> InputType? {
-        let normalizedRangeValue = normalize(rangeValue.toDouble(), lower: lower.toDouble(), higher: higher.toDouble())
-        let logDomainLower = log10(domainLower.toDouble())
-        let logDomainHigher = log10(domainHigher.toDouble())
-        let linearInterpolatedValue = interpolate(Double(normalizedRangeValue), lower: logDomainLower, higher: logDomainHigher)
-        let domainValue = pow(10, linearInterpolatedValue)
-        let downcastDomainValue = InputType.fromDouble(domainValue)
-        return transformAgainstDomain(downcastDomainValue)
+        let reconfiguredScale = range(lower: lower, higher: higher)
+        return reconfiguredScale.invert(rangeValue)
     }
 }

--- a/Sources/SwiftVizScale/PowerScale.swift
+++ b/Sources/SwiftVizScale/PowerScale.swift
@@ -17,16 +17,16 @@ public struct PowerScale<InputType: ConvertibleWithDouble & NiceValue, OutputTyp
     /// The distance or length between the upper and lower bounds of the input domain.
     public let domainExtent: InputType
 
+    /// The lower bound of the input domain.
+    public let rangeLower: OutputType?
+    /// The upper bound of the input domain.
+    public let rangeHigher: OutputType?
+
     /// A transformation value that indicates whether the output vales are constrained to the min and max of the output range.
     ///
     /// If `true`, values processed by the scale are constrained to the output range, and values processed backwards through the scale
     /// are constrained to the input domain.
     public var transformType: DomainDataTransform
-
-    /// A Boolean value that indicates the scale was configured without an explicit domain.
-    ///
-    /// Use ``withDomain(lower:higher:)`` to create a new scale with an explicit domain while keeping the same ``transformType``.
-    public var defaultDomain: Bool
 
     /// The number of ticks desired when creating the scale.
     ///
@@ -43,28 +43,19 @@ public struct PowerScale<InputType: ConvertibleWithDouble & NiceValue, OutputTyp
     ///   - exponent: The exponent for the power transforming, defaulting to `1`.
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(from lower: InputType, to higher: InputType, exponent: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        precondition(lower < higher)
+    public init(from lower: InputType = 0, to higher: InputType = 1, exponent: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
+        precondition(lower < higher, "attempting to set an inverted or empty domain: \(lower) to \(higher)")
         transformType = transform
         domainLower = lower
         domainHigher = higher
         domainExtent = higher - lower
         self.exponent = exponent
         self.desiredTicks = desiredTicks
-        defaultDomain = false
-    }
-
-    /// Creates a new power scale with a default domain.
-    ///
-    /// The default domain for the scale is `0.0...1.0`.
-    /// Use this method to create a placeholder scale that you can refine to a fully configured scale with an updated domain using ``withDomain(lower:higher:)``.
-    /// - Parameters:
-    ///   - exponent: The exponent for the power transforming, defaulting to `1`.
-    ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
-    ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(exponent: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        self.init(from: 0, to: 1, exponent: exponent, transform: transform, desiredTicks: desiredTicks)
-        defaultDomain = true
+        if let rangeLower = rangeLower, let rangeHigher = rangeHigher {
+            precondition(lower < higher, "attempting to set an inverted or empty range: \(rangeLower) to \(rangeHigher)")
+        }
+        self.rangeLower = rangeLower
+        self.rangeHigher = rangeHigher
     }
 
     /// Creates a new power scale for the upper and lower bounds of the domain range you provide.
@@ -73,8 +64,8 @@ public struct PowerScale<InputType: ConvertibleWithDouble & NiceValue, OutputTyp
     ///   - exponent: The exponent for the power transforming, defaulting to `1`.
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(_ range: ClosedRange<InputType>, exponent: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
-        self.init(from: range.lowerBound, to: range.upperBound, exponent: exponent, transform: transform, desiredTicks: desiredTicks)
+    public init(_ range: ClosedRange<InputType>, exponent: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
+        self.init(from: range.lowerBound, to: range.upperBound, exponent: exponent, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
     }
 
     /// Creates a new power scale for the domain of `0` to the value you provide.
@@ -86,21 +77,79 @@ public struct PowerScale<InputType: ConvertibleWithDouble & NiceValue, OutputTyp
     ///   - exponent: The exponent for the power transforming, defaulting to `1`.
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
-    public init(_ single: InputType, exponent: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10) {
+    public init(_ single: InputType, exponent: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
         if single > 0 {
-            self.init(from: 0, to: single, exponent: exponent, transform: transform, desiredTicks: desiredTicks)
+            self.init(from: 0, to: single, exponent: exponent, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
         } else {
-            self.init(from: single, to: 0, exponent: exponent, transform: transform, desiredTicks: desiredTicks)
+            self.init(from: single, to: 0, exponent: exponent, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
         }
     }
+
+    // testing function
+    internal func fullyConfigured() -> Bool {
+        rangeLower != nil && rangeHigher != nil
+    }
+
+    // MARK: - modifier functions
 
     /// Returns a new scale with the domain set to the values you provide.
     /// - Parameters:
     ///   - lower: The lower bound for the scale's domain.
     ///   - higher: The upper bound for the scale's domain.
-    /// - Returns: A replica of the scale, preserving ``transformType`` while applying new domain values.
-    public func withDomain(lower: InputType, higher: InputType) -> PowerScale<InputType, OutputType> {
-        type(of: self).init(from: lower, to: higher, transform: transformType, desiredTicks: desiredTicks)
+    /// - Returns: A copy of the scale with the domain values you provide.
+    public func domain(lower: InputType, higher: InputType) -> Self {
+        type(of: self).init(from: lower, to: higher, transform: transformType, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    /// Returns a new scale with the domain set to the values you provide.
+    /// - Parameters:
+    ///   - range: The range to apply as the scale's domain
+    /// - Returns: A copy of the scale with the domain values you provide.
+    public func domain(_ range: ClosedRange<InputType>) -> Self {
+        type(of: self).init(from: range.lowerBound, to: range.upperBound, transform: transformType, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    /// Returns a new scale with the range set to the values you provide.
+    /// - Parameters:
+    ///   - lower: The lower bound for the scale's range.
+    ///   - higher: The upper bound for the scale's range.
+    /// - Returns: A copy of the scale with the range values you provide.
+    public func range(lower: OutputType, higher: OutputType) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transformType, desiredTicks: desiredTicks, rangeLower: lower, rangeHigher: higher)
+    }
+
+    /// Returns a new scale with the range set to the values you provide.
+    /// - Parameters:
+    ///   - range: The range to apply as the scale's range.
+    /// - Returns: A copy of the scale with the range values you provide.
+    public func range(_ range: ClosedRange<OutputType>) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transformType, desiredTicks: desiredTicks, rangeLower: range.lowerBound, rangeHigher: range.upperBound)
+    }
+
+    /// Returns a new scale with the transform set to the value you provide.
+    /// - Parameters:
+    ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
+    /// - Returns: A copy of the scale with the transform setting you provide.
+    public func transform(_ transform: DomainDataTransform) -> Self {
+        type(of: self).init(from: domainLower, to: domainHigher, transform: transform, desiredTicks: desiredTicks, rangeLower: rangeLower, rangeHigher: rangeHigher)
+    }
+
+    // MARK: - scale functions
+
+    /// Transforms the input value using a power function and maps the resulting value into the range you provide.
+    ///
+    /// - Parameter domainValue: A value in the domain of the scale.
+    /// - Returns: A value scaled by the power function, mapped to the range you provide.
+    public func scale(_ domainValue: InputType) -> OutputType? {
+        guard let domainValue = transformAgainstDomain(domainValue), let rangeLower = rangeLower, let rangeHigher = rangeHigher else {
+            return nil
+        }
+        let powDomainValue = pow(domainValue.toDouble(), exponent)
+        let powDomainLower = pow(domainLower.toDouble(), exponent)
+        let powDomainHigher = pow(domainHigher.toDouble(), exponent)
+        let normalizedValueOnPowDomain = normalize(powDomainValue, lower: powDomainLower, higher: powDomainHigher)
+        let valueMappedToRange = interpolate(normalizedValueOnPowDomain, lower: rangeLower.toDouble(), higher: rangeHigher.toDouble())
+        return OutputType.fromDouble(valueMappedToRange)
     }
 
     /// Transforms the input value using a power function and maps the resulting value into the range you provide.
@@ -109,16 +158,9 @@ public struct PowerScale<InputType: ConvertibleWithDouble & NiceValue, OutputTyp
     /// - Parameter lower: The lower bound to the range to map to.
     /// - Parameter higher: The upper bound of the range to map to.
     /// - Returns: A value scaled by the power function, mapped to the range you provide.
-    public func scale(_ domainValue: InputType, from lower: Float, to higher: Float) -> Float? {
-        if let domainValue = transformAgainstDomain(domainValue) {
-            let powDomainValue = pow(domainValue.toDouble(), exponent)
-            let powDomainLower = pow(domainLower.toDouble(), exponent)
-            let powDomainHigher = pow(domainHigher.toDouble(), exponent)
-            let normalizedValueOnLogDomain = normalize(powDomainValue, lower: powDomainLower, higher: powDomainHigher)
-            let valueMappedToRange = interpolate(Float(normalizedValueOnLogDomain), lower: lower, higher: higher)
-            return valueMappedToRange
-        }
-        return nil
+    public func scale(_ domainValue: InputType, from lower: OutputType, to higher: OutputType) -> OutputType? {
+        let reconfiguredScale = range(lower: lower, higher: higher)
+        return reconfiguredScale.scale(domainValue)
     }
 
     /// Transforms a value within the range into the associated domain value.
@@ -127,13 +169,27 @@ public struct PowerScale<InputType: ConvertibleWithDouble & NiceValue, OutputTyp
     ///   - lower: The lower bound to the range to map from.
     ///   - higher: The upper bound to the range to map from.
     /// - Returns: A value mapped from the range back into the domain using an inverse power transform.
-    public func invert(_ rangeValue: Float, from lower: Float, to higher: Float) -> InputType? {
-        let normalizedRangeValue = normalize(rangeValue, lower: lower, higher: higher)
+    public func invert(_ rangeValue: OutputType) -> InputType? {
+        guard let rangeLower = rangeLower, let rangeHigher = rangeHigher else {
+            return nil
+        }
+        let normalizedRangeValue = normalize(rangeValue.toDouble(), lower: rangeLower.toDouble(), higher: rangeHigher.toDouble())
         let powDomainLower = pow(domainLower.toDouble(), exponent)
         let powDomainHigher = pow(domainHigher.toDouble(), exponent)
         let linearInterpolatedValue = interpolate(Double(normalizedRangeValue), lower: powDomainLower, higher: powDomainHigher)
         let domainValue = pow(linearInterpolatedValue, 1.0 / exponent)
         let downcastDomainValue = InputType.fromDouble(domainValue)
         return transformAgainstDomain(downcastDomainValue)
+    }
+
+    /// Transforms a value within the range into the associated domain value.
+    /// - Parameters:
+    ///   - rangeValue: A value in the range of the scale.
+    ///   - lower: The lower bound to the range to map from.
+    ///   - higher: The upper bound to the range to map from.
+    /// - Returns: A value mapped from the range back into the domain using an inverse power transform.
+    public func invert(_ rangeValue: OutputType, from lower: OutputType, to higher: OutputType) -> InputType? {
+        let reconfiguredScale = range(lower: lower, higher: higher)
+        return reconfiguredScale.invert(rangeValue)
     }
 }

--- a/Tests/SwiftVizScaleTests/PowerScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/PowerScaleTests.swift
@@ -33,7 +33,7 @@ class PowerScaleTests: XCTestCase {
             XCTFail()
             return
         }
-        XCTAssertEqual(result, 4.0, accuracy: 0.001)
+        XCTAssertEqual(result, 20.0, accuracy: 0.001)
     }
 
     func testPowerScale_invert_identity() throws {
@@ -51,6 +51,6 @@ class PowerScaleTests: XCTestCase {
             XCTFail()
             return
         }
-        XCTAssertEqual(result, 4, accuracy: 0.001)
+        XCTAssertEqual(result, 1.6, accuracy: 0.001)
     }
 }

--- a/Tests/SwiftVizScaleTests/ScaleTemplateTests.swift
+++ b/Tests/SwiftVizScaleTests/ScaleTemplateTests.swift
@@ -6,40 +6,40 @@
 //
 
 import Foundation
-import SwiftVizScale
+@testable import SwiftVizScale
 import XCTest
 
 class ScaleTemplateTests: XCTestCase {
     func testDefaultInitializers() throws {
         let linear = LinearScale<Double, CGFloat>()
-        XCTAssertEqual(linear.defaultDomain, true)
+        XCTAssertFalse(linear.fullyConfigured())
 
         let log = LogScale<Double, CGFloat>()
-        XCTAssertEqual(log.defaultDomain, true)
+        XCTAssertFalse(log.fullyConfigured())
 
         let power = PowerScale<Double, CGFloat>()
-        XCTAssertEqual(power.defaultDomain, true)
+        XCTAssertFalse(power.fullyConfigured())
     }
 
     func testFullyConfiguratedInitializers() throws {
         let linear = LinearScale<Double, CGFloat>(from: 0, to: 1)
-        XCTAssertEqual(linear.defaultDomain, false)
+        XCTAssertFalse(linear.fullyConfigured())
 
         let log = LogScale<Double, CGFloat>(from: 1, to: 10)
-        XCTAssertEqual(log.defaultDomain, false)
+        XCTAssertFalse(log.fullyConfigured())
 
         let power = PowerScale<Double, CGFloat>(from: 0, to: 1)
-        XCTAssertEqual(power.defaultDomain, false)
+        XCTAssertFalse(power.fullyConfigured())
     }
 
     func testRefineScaleTemplate() throws {
-        let linear = LinearScale<Double, CGFloat>().withDomain(lower: 0, higher: 1)
-        XCTAssertEqual(linear.defaultDomain, false)
+        let linear = LinearScale<Double, CGFloat>().range(lower: 0, higher: 1)
+        XCTAssertTrue(linear.fullyConfigured())
 
-        let log = LogScale<Double, CGFloat>().withDomain(lower: 1, higher: 10)
-        XCTAssertEqual(log.defaultDomain, false)
+        let log = LogScale<Double, CGFloat>().range(lower: 1, higher: 10)
+        XCTAssertTrue(log.fullyConfigured())
 
-        let power = PowerScale<Double, CGFloat>().withDomain(lower: 0, higher: 1)
-        XCTAssertEqual(power.defaultDomain, false)
+        let power = PowerScale<Double, CGFloat>().range(lower: 0, higher: 1)
+        XCTAssertTrue(power.fullyConfigured())
     }
 }


### PR DESCRIPTION
making the scale API patterns & implementation details consistent
- use modifier pattern on continuous scales
- add modifiers for range, domain, and transform
- updated continuous scale protocol to include modifier methods
- updated tests to correspond