### PR TITLE
Single domain value

### DIFF
--- a/Sources/SwiftVizScale/LinearScale.swift
+++ b/Sources/SwiftVizScale/LinearScale.swift
@@ -36,7 +36,7 @@ public struct LinearScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
     public init(from lower: InputType = 0, to higher: InputType = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
-        precondition(lower < higher, "attempting to set an inverted or empty domain: \(lower) to \(higher)")
+        precondition(lower <= higher, "attempting to set an inverted domain: \(lower) to \(higher)")
         transformType = transform
         domainLower = lower
         domainHigher = higher

--- a/Sources/SwiftVizScale/LogScale.swift
+++ b/Sources/SwiftVizScale/LogScale.swift
@@ -41,7 +41,7 @@ public struct LogScale<InputType: ConvertibleWithDouble & NiceValue, OutputType:
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
     public init(from lower: InputType = 1, to higher: InputType = 10, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
-        precondition(lower < higher, "attempting to set an inverted or empty domain: \(lower) to \(higher)")
+        precondition(lower <= higher, "attempting to set an inverted domain: \(lower) to \(higher)")
         precondition(lower.toDouble() > 0.0, "attempting to set a log scale to start at 0.0")
         transformType = transform
         domainLower = lower

--- a/Sources/SwiftVizScale/PowerScale.swift
+++ b/Sources/SwiftVizScale/PowerScale.swift
@@ -49,7 +49,7 @@ public struct PowerScale<InputType: ConvertibleWithDouble & NiceValue, OutputTyp
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
     public init(from lower: InputType = 0, to higher: InputType = 1, exponent: Double = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
-        precondition(lower < higher, "attempting to set an inverted or empty domain: \(lower) to \(higher)")
+        precondition(lower <= higher, "attempting to set an inverted domain: \(lower) to \(higher)")
         transformType = transform
         domainLower = lower
         domainHigher = higher

--- a/Sources/SwiftVizScale/RadialScale.swift
+++ b/Sources/SwiftVizScale/RadialScale.swift
@@ -43,7 +43,7 @@ public struct RadialScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
     ///   - transform: The transform constraint to apply when values fall outside the domain of the scale.
     ///   - desiredTicks: The desired number of ticks when visually representing the scale.
     public init(from lower: InputType = 0, to higher: InputType = 1, transform: DomainDataTransform = .none, desiredTicks: Int = 10, rangeLower: OutputType? = nil, rangeHigher: OutputType? = nil) {
-        precondition(lower < higher, "attempting to set an inverted or empty domain: \(lower) to \(higher)")
+        precondition(lower <= higher, "attempting to set an inverted domain: \(lower) to \(higher)")
         transformType = transform
         domainLower = lower
         domainHigher = higher

--- a/Tests/SwiftVizScaleTests/LinearScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/LinearScaleTests.swift
@@ -281,10 +281,10 @@ final class LinearScaleTests: XCTestCase {
         let updated = scale.transform(.clamp)
         XCTAssertEqual(updated.transformType, DomainDataTransform.clamp)
     }
-    
+
     func testScaleDomainOfOneValue() {
         let scale = LinearScale<Double, CGFloat>()
-        
+
         let updated = scale.domain([5.0])
         XCTAssertEqual(updated.domainLower, 5)
         XCTAssertEqual(updated.domainHigher, 5)
@@ -292,10 +292,9 @@ final class LinearScaleTests: XCTestCase {
 
     func testScaleDomainOfOneValueNiced() {
         let scale = LinearScale<Double, CGFloat>()
-        
+
         let updated = scale.domain([5.0], nice: true)
         XCTAssertEqual(updated.domainLower, 5)
         XCTAssertEqual(updated.domainHigher, 5)
     }
-
 }

--- a/Tests/SwiftVizScaleTests/LinearScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/LinearScaleTests.swift
@@ -281,4 +281,21 @@ final class LinearScaleTests: XCTestCase {
         let updated = scale.transform(.clamp)
         XCTAssertEqual(updated.transformType, DomainDataTransform.clamp)
     }
+    
+    func testScaleDomainOfOneValue() {
+        let scale = LinearScale<Double, CGFloat>()
+        
+        let updated = scale.domain([5.0])
+        XCTAssertEqual(updated.domainLower, 5)
+        XCTAssertEqual(updated.domainHigher, 5)
+    }
+
+    func testScaleDomainOfOneValueNiced() {
+        let scale = LinearScale<Double, CGFloat>()
+        
+        let updated = scale.domain([5.0], nice: true)
+        XCTAssertEqual(updated.domainLower, 5)
+        XCTAssertEqual(updated.domainHigher, 5)
+    }
+
 }

--- a/Tests/SwiftVizScaleTests/LogScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/LogScaleTests.swift
@@ -296,10 +296,10 @@ class LogScaleTests: XCTestCase {
         XCTAssertEqual(updated.domainLower, 10.0)
         XCTAssertEqual(updated.domainHigher, 51.0)
     }
-    
+
     func testScaleDomainOfOneValue() {
         let scale = LogScale<Double, CGFloat>()
-        
+
         let updated = scale.domain([5.0])
         XCTAssertEqual(updated.domainLower, 5)
         XCTAssertEqual(updated.domainHigher, 5)
@@ -307,10 +307,9 @@ class LogScaleTests: XCTestCase {
 
     func testScaleDomainOfOneValueNiced() {
         let scale = LogScale<Double, CGFloat>()
-        
+
         let updated = scale.domain([5.0], nice: true)
         XCTAssertEqual(updated.domainLower, 5)
         XCTAssertEqual(updated.domainHigher, 5)
     }
-
 }

--- a/Tests/SwiftVizScaleTests/LogScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/LogScaleTests.swift
@@ -296,4 +296,21 @@ class LogScaleTests: XCTestCase {
         XCTAssertEqual(updated.domainLower, 10.0)
         XCTAssertEqual(updated.domainHigher, 51.0)
     }
+    
+    func testScaleDomainOfOneValue() {
+        let scale = LogScale<Double, CGFloat>()
+        
+        let updated = scale.domain([5.0])
+        XCTAssertEqual(updated.domainLower, 5)
+        XCTAssertEqual(updated.domainHigher, 5)
+    }
+
+    func testScaleDomainOfOneValueNiced() {
+        let scale = LogScale<Double, CGFloat>()
+        
+        let updated = scale.domain([5.0], nice: true)
+        XCTAssertEqual(updated.domainLower, 5)
+        XCTAssertEqual(updated.domainHigher, 5)
+    }
+
 }

--- a/Tests/SwiftVizScaleTests/PowerScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/PowerScaleTests.swift
@@ -125,10 +125,10 @@ class PowerScaleTests: XCTestCase {
         XCTAssertEqual(updated.domainLower, 1.0)
         XCTAssertEqual(updated.domainHigher, 15.0)
     }
-    
+
     func testScaleDomainOfOneValue() {
         let scale = PowerScale<Double, CGFloat>()
-        
+
         let updated = scale.domain([5.0])
         XCTAssertEqual(updated.domainLower, 5)
         XCTAssertEqual(updated.domainHigher, 5)
@@ -136,10 +136,9 @@ class PowerScaleTests: XCTestCase {
 
     func testScaleDomainOfOneValueNiced() {
         let scale = PowerScale<Double, CGFloat>()
-        
+
         let updated = scale.domain([5.0], nice: true)
         XCTAssertEqual(updated.domainLower, 5)
         XCTAssertEqual(updated.domainHigher, 5)
     }
-
 }

--- a/Tests/SwiftVizScaleTests/PowerScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/PowerScaleTests.swift
@@ -125,4 +125,21 @@ class PowerScaleTests: XCTestCase {
         XCTAssertEqual(updated.domainLower, 1.0)
         XCTAssertEqual(updated.domainHigher, 15.0)
     }
+    
+    func testScaleDomainOfOneValue() {
+        let scale = PowerScale<Double, CGFloat>()
+        
+        let updated = scale.domain([5.0])
+        XCTAssertEqual(updated.domainLower, 5)
+        XCTAssertEqual(updated.domainHigher, 5)
+    }
+
+    func testScaleDomainOfOneValueNiced() {
+        let scale = PowerScale<Double, CGFloat>()
+        
+        let updated = scale.domain([5.0], nice: true)
+        XCTAssertEqual(updated.domainLower, 5)
+        XCTAssertEqual(updated.domainHigher, 5)
+    }
+
 }

--- a/Tests/SwiftVizScaleTests/RadialScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/RadialScaleTests.swift
@@ -144,10 +144,10 @@ class RadialScaleTests: XCTestCase {
         XCTAssertEqual(updated.domainLower, 0.0)
         XCTAssertEqual(updated.domainHigher, 20.0)
     }
-    
+
     func testScaleDomainOfOneValue() {
         let scale = RadialScale<Double, CGFloat>()
-        
+
         let updated = scale.domain([5.0])
         XCTAssertEqual(updated.domainLower, 5)
         XCTAssertEqual(updated.domainHigher, 5)
@@ -155,10 +155,9 @@ class RadialScaleTests: XCTestCase {
 
     func testScaleDomainOfOneValueNiced() {
         let scale = RadialScale<Double, CGFloat>()
-        
+
         let updated = scale.domain([5.0], nice: true)
         XCTAssertEqual(updated.domainLower, 5)
         XCTAssertEqual(updated.domainHigher, 5)
     }
-
 }

--- a/Tests/SwiftVizScaleTests/RadialScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/RadialScaleTests.swift
@@ -144,4 +144,21 @@ class RadialScaleTests: XCTestCase {
         XCTAssertEqual(updated.domainLower, 0.0)
         XCTAssertEqual(updated.domainHigher, 20.0)
     }
+    
+    func testScaleDomainOfOneValue() {
+        let scale = RadialScale<Double, CGFloat>()
+        
+        let updated = scale.domain([5.0])
+        XCTAssertEqual(updated.domainLower, 5)
+        XCTAssertEqual(updated.domainHigher, 5)
+    }
+
+    func testScaleDomainOfOneValueNiced() {
+        let scale = RadialScale<Double, CGFloat>()
+        
+        let updated = scale.domain([5.0], nice: true)
+        XCTAssertEqual(updated.domainLower, 5)
+        XCTAssertEqual(updated.domainHigher, 5)
+    }
+
 }


### PR DESCRIPTION
for continuous scales, allow setting a domain with a single value (don't require the domain to have an explicit `<` relationship)