### PR TITLE
tick updates

### DIFF
--- a/Sources/SwiftVizScale/BandScale.swift
+++ b/Sources/SwiftVizScale/BandScale.swift
@@ -232,20 +232,38 @@ public struct BandScale<CategoryType: Comparable, OutputType: ConvertibleWithDou
 }
 
 extension BandScale: CustomStringConvertible {
+    /// The description of the scale.
     public var description: String {
         "\(scaleType)\(domain)->[\(String(describing: rangeLower)):\(String(describing: rangeHigher))]"
     }
 }
 
 public extension BandScale {
-    func ticks(rangeLower lower: RangeType, rangeHigher higher: RangeType) -> [Tick<RangeType>] {
+    /// Returns an array of the strings that make up the ticks for the scale.
+    /// - Parameter formatter: An optional formatter to convert the domain values into strings.
+    func defaultTickValues(formatter: Formatter? = nil) -> [String] {
+        domain.map { value in
+            if let formatter = formatter {
+                return formatter.string(for: value) ?? ""
+            } else {
+                return String("\(value)")
+            }
+        }
+    }
+
+    /// Returns an array of the locations within the output range to locate ticks for the scale.
+    /// - Parameters:
+    ///   - rangeLower: the lower value for the range into which to position the ticks.
+    ///   - rangeHigher: The higher value for the range into which to position the ticks.
+    ///   - formatter: An optional formatter to convert the domain values into strings.
+    func ticks(rangeLower lower: RangeType, rangeHigher higher: RangeType, formatter: Formatter? = nil) -> [Tick<RangeType>] {
         // NOTE(heckj): perf: for a larger number of ticks, it may be more efficient to assign the range to a temp scale and then iterate on that...
         let updatedScale = range(lower: lower, higher: higher)
         return domain.compactMap { tickValue in
             guard let tickRangeValue = updatedScale.scale(tickValue) else {
                 return nil
             }
-            return Tick(value: tickValue, location: tickRangeValue.middle)
+            return Tick(value: tickValue, location: tickRangeValue.middle, formatter: formatter)
         }
     }
 }

--- a/Sources/SwiftVizScale/DiscreteScale.swift
+++ b/Sources/SwiftVizScale/DiscreteScale.swift
@@ -32,5 +32,14 @@ public protocol DiscreteScale: Scale, CustomStringConvertible {
     /// An array of the types the scale maps into.
     var domain: [InputType] { get }
 
-    func ticks(rangeLower: RangeType, rangeHigher: RangeType) -> [Tick<RangeType>]
+    /// Returns an array of the strings that make up the ticks for the scale.
+    /// - Parameter formatter: An optional formatter to convert the domain values into strings.
+    func defaultTickValues(formatter: Formatter?) -> [String]
+
+    /// Returns an array of the locations within the output range to locate ticks for the scale.
+    /// - Parameters:
+    ///   - rangeLower: the lower value for the range into which to position the ticks.
+    ///   - rangeHigher: The higher value for the range into which to position the ticks.
+    ///   - formatter: An optional formatter to convert the domain values into strings.
+    func ticks(rangeLower: RangeType, rangeHigher: RangeType, formatter: Formatter?) -> [Tick<RangeType>]
 }

--- a/Sources/SwiftVizScale/LinearScale.swift
+++ b/Sources/SwiftVizScale/LinearScale.swift
@@ -26,7 +26,7 @@ public struct LinearScale<InputType: ConvertibleWithDouble & NiceValue, OutputTy
 
     /// The number of ticks desired when creating the scale.
     ///
-    /// This number may not match the number of ticks returned by ``TickScale/tickValues(_:from:to:)``
+    /// This number may not match the number of ticks returned by ``ContinuousScale/tickValues(_:from:to:formatter:)``
     public let desiredTicks: Int
 
     /// Creates a new linear scale for the upper and lower bounds of the domain you provide.

--- a/Sources/SwiftVizScale/NiceValue.swift
+++ b/Sources/SwiftVizScale/NiceValue.swift
@@ -59,8 +59,49 @@ public protocol NiceValue {
     static func rangeOfNiceValues(min: NumberType, max: NumberType, ofSize size: Int) -> [NumberType]
 }
 
-// MARK: - Double
+// This would be WAY more sane if it could expand upon `Real` from swift-numerics, such that any
+// type that conformed to `Real` could be used to generate a "nice" value or series of values.
+// Then this would collapse down to `Real` and `Int` overloads.
+//
+//extension NiceValue where NumberType: Real {
+//
+//    public static func niceVersion(for number: NumberType, min: Bool) -> NumberType {
+//        let negativeInput: Bool = number < 0
+//        let positiveNumber: NumberType = abs(number)
+//        let exponent = floor(NumberType.log(positiveNumber))
+//        let fraction = positiveNumber / NumberType.pow(10, exponent)
+//        let niceFraction: NumberType
+//
+//        if min {
+//            if fraction <= 1.5 {
+//                niceFraction = 1
+//            } else if fraction <= 3 {
+//                niceFraction = 2
+//            } else if fraction <= 7 {
+//                niceFraction = 5
+//            } else {
+//                niceFraction = 10
+//            }
+//        } else {
+//            if fraction <= 1 {
+//                niceFraction = 1
+//            } else if fraction <= 2 {
+//                niceFraction = 2
+//            } else if fraction <= 5 {
+//                niceFraction = 5
+//            } else {
+//                niceFraction = 10
+//            }
+//        }
+//        if negativeInput {
+//            return -1.0 * niceFraction * NumberType.pow(10, exponent)
+//        }
+//        return niceFraction * NumberType.pow(10, exponent)
+//    }
+//
+//}
 
+// MARK: - Double
 extension Double: NiceValue {
     public typealias NumberType = Double
 
@@ -235,7 +276,7 @@ extension Double: NiceValue {
                     break
                 }
             }
-            print(result)
+//            print(result)
             return result
         }
     }

--- a/Sources/SwiftVizScale/PointScale.swift
+++ b/Sources/SwiftVizScale/PointScale.swift
@@ -179,20 +179,38 @@ public struct PointScale<CategoryType: Comparable, OutputType: ConvertibleWithDo
 }
 
 extension PointScale: CustomStringConvertible {
+    /// The description of the scale.
     public var description: String {
         "\(scaleType)\(domain)->[\(String(describing: rangeLower)):\(String(describing: rangeHigher))]"
     }
 }
 
 public extension PointScale {
-    func ticks(rangeLower lower: RangeType, rangeHigher higher: RangeType) -> [Tick<RangeType>] {
+    /// Returns an array of the strings that make up the ticks for the scale.
+    /// - Parameter formatter: An optional formatter to convert the domain values into strings.
+    func defaultTickValues(formatter: Formatter? = nil) -> [String] {
+        domain.map { value in
+            if let formatter = formatter {
+                return formatter.string(for: value) ?? ""
+            } else {
+                return String("\(value)")
+            }
+        }
+    }
+
+    /// Returns an array of the locations within the output range to locate ticks for the scale.
+    /// - Parameters:
+    ///   - rangeLower: the lower value for the range into which to position the ticks.
+    ///   - rangeHigher: The higher value for the range into which to position the ticks.
+    ///   - formatter: An optional formatter to convert the domain values into strings.
+    func ticks(rangeLower lower: RangeType, rangeHigher higher: RangeType, formatter: Formatter? = nil) -> [Tick<RangeType>] {
         // NOTE(heckj): perf: for a larger number of ticks, it may be more efficient to assign the range to a temp scale and then iterate on that...
         let updatedScale = range(lower: lower, higher: higher)
         return domain.compactMap { tickValue in
             guard let tickRangeValue = updatedScale.scale(tickValue) else {
                 return nil
             }
-            return Tick(value: tickValue, location: tickRangeValue)
+            return Tick(value: tickValue, location: tickRangeValue, formatter: formatter)
         }
     }
 }

--- a/Tests/SwiftVizScaleTests/ExternalPackageTests.swift
+++ b/Tests/SwiftVizScaleTests/ExternalPackageTests.swift
@@ -12,25 +12,25 @@ final class PackagingTests: XCTestCase {
     func testManualTicks() {
         let scale = LinearScale<Double, CGFloat>(from: 0.0, to: 10.0, transform: .none)
         // verifies the method is visible externally - else this won't compile
-        let ticks = scale.tickValues([2.0], from: 0.0, to: 10.0)
+        let ticks = scale.ticksFromValues([2.0], from: 0.0, to: 10.0)
         XCTAssertEqual(ticks.count, 1)
     }
 
     func testManualTicksOutsideRangeNone() {
         let scale = LinearScale<Double, CGFloat>(from: 0.0, to: 10.0, transform: .none)
-        let ticks = scale.tickValues([2.0, 4.0, 8.0, 16.0], from: 0.0, to: 10.0)
+        let ticks = scale.ticksFromValues([2.0, 4.0, 8.0, 16.0], from: 0.0, to: 10.0)
         XCTAssertEqual(ticks.count, 3)
     }
 
     func testManualTicksOutsideRangeClamped() {
         let scale = LinearScale<Double, CGFloat>(from: 0.0, to: 10.0, transform: .clamp)
-        let ticks = scale.tickValues([2.0, 4.0, 8.0, 16.0], from: 0.0, to: 10.0)
+        let ticks = scale.ticksFromValues([2.0, 4.0, 8.0, 16.0], from: 0.0, to: 10.0)
         XCTAssertEqual(ticks.count, 3)
     }
 
     func testManualTicksOutsideRangeDropped() {
         let scale = LinearScale<Double, CGFloat>(from: 0.0, to: 10.0, transform: .drop)
-        let ticks = scale.tickValues([2.0, 4.0, 8.0, 16.0], from: 0.0, to: 10.0)
+        let ticks = scale.ticksFromValues([2.0, 4.0, 8.0, 16.0], from: 0.0, to: 10.0)
         XCTAssertEqual(ticks.count, 3)
     }
 

--- a/Tests/SwiftVizScaleTests/LinearScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/LinearScaleTests.swift
@@ -67,7 +67,7 @@ final class LinearScaleTests: XCTestCase {
         XCTAssertEqual(myScale.transformType, .none)
 
         let testRange = Float(0) ... Float(100.0)
-        let manualTicks = myScale.tickValues([0.1, 0.5], from: testRange.lowerBound, to: testRange.upperBound)
+        let manualTicks = myScale.ticksFromValues([0.1, 0.5], from: testRange.lowerBound, to: testRange.upperBound)
 
         XCTAssertEqual(manualTicks.count, 2)
         for tick in manualTicks {
@@ -83,7 +83,7 @@ final class LinearScaleTests: XCTestCase {
         XCTAssertEqual(myScale.transformType, .none)
 
         let testRange = Float(0) ... Float(100.0)
-        let manualTicks = myScale.tickValues([0.1, 0.5], from: testRange.lowerBound, to: testRange.upperBound)
+        let manualTicks = myScale.ticksFromValues([0.1, 0.5], from: testRange.lowerBound, to: testRange.upperBound)
 
         XCTAssertEqual(manualTicks.count, 2)
         for tick in manualTicks {

--- a/Tests/SwiftVizScaleTests/LogScaleTests.swift
+++ b/Tests/SwiftVizScaleTests/LogScaleTests.swift
@@ -98,7 +98,7 @@ class LogScaleTests: XCTestCase {
 
         let testRange = Float(0) ... Float(100.0)
 
-        let manualTicks = myScale.tickValues([0.1, 1, 10], from: testRange.lowerBound, to: testRange.upperBound)
+        let manualTicks = myScale.ticksFromValues([0.1, 1, 10], from: testRange.lowerBound, to: testRange.upperBound)
 
         XCTAssertEqual(manualTicks.count, 3)
         for tick in manualTicks {
@@ -133,7 +133,7 @@ class LogScaleTests: XCTestCase {
 
         let testRange = Float(0.0) ... Float(100.0)
 
-        let manualTicks = myScale.tickValues([0.1, 1, 10, 100, 1000], from: testRange.lowerBound, to: testRange.upperBound)
+        let manualTicks = myScale.ticksFromValues([0.1, 1, 10, 100, 1000], from: testRange.lowerBound, to: testRange.upperBound)
 
         XCTAssertEqual(manualTicks.count, 3)
         for tick in manualTicks {

--- a/Tests/SwiftVizScaleTests/TickTests.swift
+++ b/Tests/SwiftVizScaleTests/TickTests.swift
@@ -98,11 +98,41 @@ final class TickTests: XCTestCase {
         print(ticks)
     }
 
+    func testAnyContinuousScaleDefaultTickValues() {
+        let scale = AnyContinuousScale(LinearScale<CGFloat, CGFloat>(from: 0, to: 10))
+        XCTAssertNotNil(scale)
+        let ticks = scale.defaultTickValues()
+        XCTAssertEqual(ticks.count, 6)
+        print(ticks)
+    }
+
     func testAnyContinuousScaleDefinedTicks() {
         let scale = AnyContinuousScale(LinearScale<Double, CGFloat>(from: 0, to: 10))
         XCTAssertNotNil(scale)
-        let ticks = scale.tickValues([-1, 3, 7, 9, 11], from: 0, to: 100)
+        let ticks = scale.ticksFromValues([-1, 3, 7, 9, 11], from: 0, to: 100)
         XCTAssertEqual(ticks.count, 3)
         print(ticks)
+    }
+
+    func testAnyContinuousScaleValidTickValues() {
+        let scale = AnyContinuousScale(LinearScale<Double, CGFloat>(from: 0, to: 10))
+        XCTAssertNotNil(scale)
+        let ticks = scale.validTickValues([-1, 3, 7, 9, 11])
+        XCTAssertEqual(ticks.count, 3)
+        print(ticks)
+    }
+
+    func testBandTickValues() {
+        let domainValues: [String] = ["1", "2", "a", "b"]
+        let scale = BandScale<String, CGFloat>(domainValues)
+        let tickValues = scale.defaultTickValues()
+        XCTAssertEqual(tickValues, domainValues)
+    }
+
+    func testPointTickValues() {
+        let domainValues: [String] = ["1", "2", "a", "b"]
+        let scale = PointScale<String, CGFloat>(domainValues)
+        let tickValues = scale.defaultTickValues()
+        XCTAssertEqual(tickValues, domainValues)
     }
 }


### PR DESCRIPTION
- added methods to get default tick values just in terms of the strings
- updated tick methods to pass through a formatter, if provided - defaulting to `nil`
- added methods on Point and Band scales to get lists of strings for their ticks