### PR TITLE
LCH cleanup

### DIFF
--- a/Sources/SwiftVizScale/Documentation.docc/LCH.md
+++ b/Sources/SwiftVizScale/Documentation.docc/LCH.md
@@ -5,3 +5,8 @@
 ### Interpolating Colors
 
 - ``SwiftVizScale/LCH/interpolate(_:_:t:)``
+
+### Converting Into and Out of LCH Color Space
+
+- ``SwiftVizScale/LCH/color(from:)``
+- ``SwiftVizScale/LCH/components(from:)``

--- a/Sources/VisualTests/InterpolationView.swift
+++ b/Sources/VisualTests/InterpolationView.swift
@@ -12,10 +12,11 @@ struct InterpolationView: View {
     var endColor: CGColor
     var colorspace: CGColorSpace
     func color(_ stepValue: Int) -> CGColor {
-        LCH.interpolate(startColor,
-                        endColor,
-                        t: normalize(Double(stepValue), lower: 0.0, higher: steps - 1),
-                        using: colorspace)
+        let i = ColorInterpolator(startColor, endColor)
+        return i.interpolate(startColor,
+                             endColor,
+                             t: normalize(Double(stepValue), lower: 0.0, higher: steps - 1),
+                             using: colorspace)
     }
 
     var body: some View {


### PR DESCRIPTION
moving general colorspace interpolation into ColorInterpolator instance, and cleaning up LCH as it's own thing to potentially externalize